### PR TITLE
build: downloading snapshot artifacts from HTTPS instead of HTTP sinc…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,7 +193,7 @@
     <repositories>
         <repository>
             <id>oss.sonatype.org-snapshot</id>
-            <url>http://oss.sonatype.org/content/repositories/snapshots</url>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
             <releases>
                 <enabled>false</enabled>
             </releases>


### PR DESCRIPTION
…e the latter is causing the build to fail on GitHub Actions